### PR TITLE
add -watch config flag to support all of the CPUs features on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,9 @@
                     <outputDirectory>${project.build.directory}/distributions</outputDirectory>
                     <workDirectory>${project.build.directory}/assembly/work</workDirectory>
                     <skipAssembly>true</skipAssembly>
+					<compilerArgs>
+						<arg>-march=compatibility</arg>
+					</compilerArgs>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
When you try to run ".\ttcli init" in Windows 10, it is not going to execute and shows this message:
 
The current machine does not support all of the following CPU features that are required by the image: [CX8, CMOV, FXSR, MMX, SSE, SSE2, SSE3, SSSE3, SSE4_1, SSE4_2, POPCNT, LZCNT, AVX, AVX2, BMI1, BMI2, FMA].
Please rebuild the executable with an appropriate setting of the -march option.

So you can use a maven configuration args to fix the issue and rebuild the project.

<build>
    <plugins>
        <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-compiler-plugin</artifactId>
            <configuration>
               <!-- This part -->
                <compilerArgs>
                    <arg>-march=compatibility</arg>
                </compilerArgs>
            </configuration>
        </plugin>
    </plugins>
</build>

