### PR TITLE
Update ExternalProcessRunner to print details about failures

### DIFF
--- a/src/main/java/io/github/wimdeblauwe/ttcli/util/ExternalProcessRunner.java
+++ b/src/main/java/io/github/wimdeblauwe/ttcli/util/ExternalProcessRunner.java
@@ -34,7 +34,7 @@ public final class ExternalProcessRunner {
             }
             return output.toString();
         } catch (IOException e) {
-            throw new ExternalProcessException(errorMessageSupplier.get(), e);
+            throw new ExternalProcessException(errorMessageSupplier.get() + ": " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
The exception message is printed out, making it easier to find the issue.